### PR TITLE
Use a proper namespace for this project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 arrow
-duckdb
 
 # build is out
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set_target_properties(sqlfliteserver PROPERTIES PUBLIC_HEADER ${HEADER_FILES})
 target_include_directories(sqlfliteserver PRIVATE
         src/sqlite
         src/duckdb
+        src/library/include
         ${SQLITE_INCLUDE_DIR}
         ${DUCKDB_INCLUDE_DIR}
         ${JWT_CPP_INCLUDE_DIR}

--- a/src/duckdb/duckdb_server.h
+++ b/src/duckdb/duckdb_server.h
@@ -24,20 +24,18 @@
 
 #include <arrow/api.h>
 #include <arrow/flight/sql/server.h>
+#include "flight_sql_fwd.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
 /// \brief Convert a column type to a ArrowType.
 /// \param duckdb_type the duckdb type.
 /// \return            The equivalent ArrowType.
-std::shared_ptr<DataType> GetArrowType(const char *duckdb_type);
+std::shared_ptr<arrow::DataType> GetArrowType(const char *duckdb_type);
 
 /// \brief Example implementation of FlightSqlServerBase backed by an in-memory DuckDB
 ///        database.
-class DuckDBFlightSqlServer : public FlightSqlServerBase {
+class DuckDBFlightSqlServer : public flight::sql::FlightSqlServerBase {
  public:
   ~DuckDBFlightSqlServer() override;
 
@@ -46,102 +44,121 @@ class DuckDBFlightSqlServer : public FlightSqlServerBase {
 
   /// \brief Auxiliary method used to execute an arbitrary SQL statement on the underlying
   ///        SQLite database.
-  Status ExecuteSql(const std::string &sql);
+  arrow::Status ExecuteSql(const std::string &sql);
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoStatement(
-      const ServerCallContext &context, const StatementQuery &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::StatementQuery &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetStatement(
-      const ServerCallContext &context, const StatementQueryTicket &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::StatementQueryTicket &command) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoCatalogs(
-      const ServerCallContext &context, const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoCatalogs(
+      const flight::ServerCallContext &context,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetCatalogs(
-      const ServerCallContext &context) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetCatalogs(
+      const flight::ServerCallContext &context) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoSchemas(
-      const ServerCallContext &context, const GetDbSchemas &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoSchemas(
+      const flight::ServerCallContext &context, const flight::sql::GetDbSchemas &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetDbSchemas(
-      const ServerCallContext &context, const GetDbSchemas &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetDbSchemas(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetDbSchemas &command) override;
 
   arrow::Result<int64_t> DoPutCommandStatementUpdate(
-      const ServerCallContext &context, const StatementUpdate &update) override;
+      const flight::ServerCallContext &context,
+      const flight::sql::StatementUpdate &update) override;
 
-  arrow::Result<ActionCreatePreparedStatementResult> CreatePreparedStatement(
-      const ServerCallContext &context,
-      const ActionCreatePreparedStatementRequest &request) override;
+  arrow::Result<flight::sql::ActionCreatePreparedStatementResult> CreatePreparedStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::ActionCreatePreparedStatementRequest &request) override;
 
-  Status ClosePreparedStatement(
-      const ServerCallContext &context,
-      const ActionClosePreparedStatementRequest &request) override;
+  arrow::Status ClosePreparedStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::ActionClosePreparedStatementRequest &request) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoPreparedStatement(
-      const ServerCallContext &context, const PreparedStatementQuery &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoPreparedStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::PreparedStatementQuery &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetPreparedStatement(
-      const ServerCallContext &context, const PreparedStatementQuery &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetPreparedStatement(
+      const flight::ServerCallContext &context,
+      const flight::sql::PreparedStatementQuery &command) override;
 
-  Status DoPutPreparedStatementQuery(const ServerCallContext &context,
-                                     const PreparedStatementQuery &command,
-                                     FlightMessageReader *reader,
-                                     FlightMetadataWriter *writer) override;
+  arrow::Status DoPutPreparedStatementQuery(
+      const flight::ServerCallContext &context,
+      const flight::sql::PreparedStatementQuery &command,
+      flight::FlightMessageReader *reader, flight::FlightMetadataWriter *writer) override;
 
   arrow::Result<int64_t> DoPutPreparedStatementUpdate(
-      const ServerCallContext &context, const PreparedStatementUpdate &command,
-      FlightMessageReader *reader) override;
+      const flight::ServerCallContext &context,
+      const flight::sql::PreparedStatementUpdate &command,
+      flight::FlightMessageReader *reader) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoTables(
-      const ServerCallContext &context, const GetTables &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoTables(
+      const flight::ServerCallContext &context, const flight::sql::GetTables &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetTables(
-      const ServerCallContext &context, const GetTables &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetTables(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetTables &command) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoTableTypes(
-      const ServerCallContext &context, const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoTableTypes(
+      const flight::ServerCallContext &context,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetTableTypes(
-      const ServerCallContext &context) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetTableTypes(
+      const flight::ServerCallContext &context) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoImportedKeys(
-      const ServerCallContext &context, const GetImportedKeys &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoImportedKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetImportedKeys &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetImportedKeys(
-      const ServerCallContext &context, const GetImportedKeys &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetImportedKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetImportedKeys &command) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoExportedKeys(
-      const ServerCallContext &context, const GetExportedKeys &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoExportedKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetExportedKeys &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetExportedKeys(
-      const ServerCallContext &context, const GetExportedKeys &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetExportedKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetExportedKeys &command) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoCrossReference(
-      const ServerCallContext &context, const GetCrossReference &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoCrossReference(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetCrossReference &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetCrossReference(
-      const ServerCallContext &context, const GetCrossReference &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetCrossReference(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetCrossReference &command) override;
 
-  arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoPrimaryKeys(
-      const ServerCallContext &context, const GetPrimaryKeys &command,
-      const FlightDescriptor &descriptor) override;
+  arrow::Result<std::unique_ptr<flight::FlightInfo>> GetFlightInfoPrimaryKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetPrimaryKeys &command,
+      const flight::FlightDescriptor &descriptor) override;
 
-  arrow::Result<std::unique_ptr<FlightDataStream>> DoGetPrimaryKeys(
-      const ServerCallContext &context, const GetPrimaryKeys &command) override;
+  arrow::Result<std::unique_ptr<flight::FlightDataStream>> DoGetPrimaryKeys(
+      const flight::ServerCallContext &context,
+      const flight::sql::GetPrimaryKeys &command) override;
 
-  arrow::Result<ActionBeginTransactionResult> BeginTransaction(
-      const ServerCallContext &context,
-      const ActionBeginTransactionRequest &request) override;
+  arrow::Result<flight::sql::ActionBeginTransactionResult> BeginTransaction(
+      const flight::ServerCallContext &context,
+      const flight::sql::ActionBeginTransactionRequest &request) override;
 
-  Status EndTransaction(const ServerCallContext &context,
-                        const ActionEndTransactionRequest &request) override;
+  arrow::Status EndTransaction(
+      const flight::ServerCallContext &context,
+      const flight::sql::ActionEndTransactionRequest &request) override;
 
  private:
   class Impl;
@@ -151,7 +168,4 @@ class DuckDBFlightSqlServer : public FlightSqlServerBase {
   explicit DuckDBFlightSqlServer(std::shared_ptr<Impl> impl);
 };
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_sql_info.cpp
+++ b/src/duckdb/duckdb_sql_info.cpp
@@ -15,21 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "duckdb_sql_info.h"
+#include <cstdint>
 
 #include <duckdb.hpp>
 #include <arrow/flight/sql/types.h>
 #include "arrow/util/config.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+#include "duckdb_sql_info.h"
+#include "flight_sql_fwd.h"
+
+namespace sql = flight::sql;
+
+namespace sqlflite::ddb {
 
 // clang-format off
 /// \brief Gets the mapping from SQL info ids to SqlInfoResult instances.
 /// \return the cache.
-SqlInfoResultMap GetSqlInfoResultMap() {
+sql::SqlInfoResultMap GetSqlInfoResultMap() {
+  using SqlInfo = sql::SqlInfoOptions::SqlInfo;
+  using SqlInfoOptions = sql::SqlInfoOptions;
+  using SqlInfoResult = sql::SqlInfoResult;
+
   return {
       {SqlInfoOptions::SqlInfo::FLIGHT_SQL_SERVER_NAME,
        SqlInfoResult(std::string("db_name"))},
@@ -50,17 +56,17 @@ SqlInfoResultMap GetSqlInfoResultMap() {
        SqlInfoResult(true)},
       {SqlInfoOptions::SqlInfo::SQL_DDL_TABLE, SqlInfoResult(true)},
       {SqlInfoOptions::SqlInfo::SQL_IDENTIFIER_CASE,
-       SqlInfoResult(int64_t(SqlInfoOptions::SqlSupportedCaseSensitivity::
+       SqlInfoResult(static_cast<int64_t>(SqlInfoOptions::SqlSupportedCaseSensitivity::
                                  SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
       {SqlInfoOptions::SqlInfo::SQL_IDENTIFIER_QUOTE_CHAR,
        SqlInfoResult(std::string("\""))},
       {SqlInfoOptions::SqlInfo::SQL_QUOTED_IDENTIFIER_CASE,
-       SqlInfoResult(int64_t(SqlInfoOptions::SqlSupportedCaseSensitivity::
+       SqlInfoResult(static_cast<int64_t>(SqlInfoOptions::SqlSupportedCaseSensitivity::
                                  SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
       {SqlInfoOptions::SqlInfo::SQL_ALL_TABLES_ARE_SELECTABLE, SqlInfoResult(true)},
       {SqlInfoOptions::SqlInfo::SQL_NULL_ORDERING,
        SqlInfoResult(
-           int64_t(SqlInfoOptions::SqlNullOrdering::SQL_NULLS_SORTED_AT_END))},
+           static_cast<int64_t>(SqlInfoOptions::SqlNullOrdering::SQL_NULLS_SORTED_AT_END))},
       {SqlInfoOptions::SqlInfo::SQL_KEYWORDS,
        SqlInfoResult(std::vector<std::string>({"ABORT_P"
                                                 "ABSOLUTE_P"
@@ -654,7 +660,4 @@ SqlInfoResultMap GetSqlInfoResultMap() {
 }
 // clang-format on
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_sql_info.h
+++ b/src/duckdb/duckdb_sql_info.h
@@ -18,17 +18,12 @@
 #pragma once
 
 #include <arrow/flight/sql/types.h>
+#include "flight_sql_fwd.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
 /// \brief Gets the mapping from SQL info ids to SqlInfoResult instances.
 /// \return the cache.
-SqlInfoResultMap GetSqlInfoResultMap();
+flight::sql::SqlInfoResultMap GetSqlInfoResultMap();
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -27,44 +27,42 @@
 #include <arrow/c/bridge.h>
 #include "duckdb_server.h"
 
+using arrow::Status;
 using duckdb::QueryResult;
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
-std::shared_ptr<DataType> GetDataTypeFromDuckDbType(
+std::shared_ptr<arrow::DataType> GetDataTypeFromDuckDbType(
     const duckdb::LogicalType duckdb_type) {
   const duckdb::LogicalTypeId column_type_id = duckdb_type.id();
   switch (column_type_id) {
     case duckdb::LogicalTypeId::INTEGER:
-      return int32();
+      return arrow::int32();
     case duckdb::LogicalTypeId::DECIMAL: {
       uint8_t width = 0;
       uint8_t scale = 0;
       bool dec_properties = duckdb_type.GetDecimalProperties(width, scale);
-      return decimal(scale, width);
+      return arrow::decimal(scale, width);
     }
     case duckdb::LogicalTypeId::FLOAT:
-      return float32();
+      return arrow::float32();
     case duckdb::LogicalTypeId::DOUBLE:
-      return float64();
+      return arrow::float64();
     case duckdb::LogicalTypeId::CHAR:
     case duckdb::LogicalTypeId::VARCHAR:
-      return utf8();
+      return arrow::utf8();
     case duckdb::LogicalTypeId::BLOB:
-      return binary();
+      return arrow::binary();
     case duckdb::LogicalTypeId::TINYINT:
-      return int8();
+      return arrow::int8();
     case duckdb::LogicalTypeId::SMALLINT:
-      return int16();
+      return arrow::int16();
     case duckdb::LogicalTypeId::BIGINT:
-      return int64();
+      return arrow::int64();
     case duckdb::LogicalTypeId::BOOLEAN:
-      return boolean();
+      return arrow::boolean();
     case duckdb::LogicalTypeId::DATE:
-      return date32();
+      return arrow::date32();
     case duckdb::LogicalTypeId::TIME:
     case duckdb::LogicalTypeId::TIMESTAMP_MS:
       return timestamp(arrow::TimeUnit::MILLI);
@@ -78,13 +76,13 @@ std::shared_ptr<DataType> GetDataTypeFromDuckDbType(
       return duration(
           arrow::TimeUnit::MICRO);  // ASSUMING MICRO AS DUCKDB's DOCS DOES NOT SPECIFY
     case duckdb::LogicalTypeId::UTINYINT:
-      return uint8();
+      return arrow::uint8();
     case duckdb::LogicalTypeId::USMALLINT:
-      return uint16();
+      return arrow::uint16();
     case duckdb::LogicalTypeId::UINTEGER:
-      return uint32();
+      return arrow::uint32();
     case duckdb::LogicalTypeId::UBIGINT:
-      return int64();
+      return arrow::int64();
     case duckdb::LogicalTypeId::INVALID:
     case duckdb::LogicalTypeId::SQLNULL:
     case duckdb::LogicalTypeId::UNKNOWN:
@@ -93,7 +91,7 @@ std::shared_ptr<DataType> GetDataTypeFromDuckDbType(
     case duckdb::LogicalTypeId::TIMESTAMP_TZ:
     case duckdb::LogicalTypeId::TIME_TZ:
     case duckdb::LogicalTypeId::HUGEINT:
-      return decimal128(38, 0);
+      return arrow::decimal128(38, 0);
     case duckdb::LogicalTypeId::POINTER:
     case duckdb::LogicalTypeId::VALIDITY:
     case duckdb::LogicalTypeId::UUID:
@@ -103,7 +101,7 @@ std::shared_ptr<DataType> GetDataTypeFromDuckDbType(
     case duckdb::LogicalTypeId::TABLE:
     case duckdb::LogicalTypeId::ENUM:
     default:
-      return null();
+      return arrow::null();
   }
 }
 
@@ -130,8 +128,8 @@ arrow::Result<int> DuckDBStatement::Execute() {
   return 0;
 }
 
-arrow::Result<std::shared_ptr<RecordBatch>> DuckDBStatement::FetchResult() {
-  std::shared_ptr<RecordBatch> record_batch;
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> DuckDBStatement::FetchResult() {
+  std::shared_ptr<arrow::RecordBatch> record_batch;
   ArrowArray res_arr;
   ArrowSchema res_schema;
   duckdb::ClientProperties res_options;
@@ -165,7 +163,7 @@ arrow::Result<int64_t> DuckDBStatement::ExecuteUpdate() {
   return result->get()->num_rows();
 }
 
-arrow::Result<std::shared_ptr<Schema>> DuckDBStatement::GetSchema() const {
+arrow::Result<std::shared_ptr<arrow::Schema>> DuckDBStatement::GetSchema() const {
   // get the names and types of the result schema
   auto names = stmt_->GetNames();
   auto types = stmt_->GetTypes();
@@ -181,7 +179,4 @@ arrow::Result<std::shared_ptr<Schema>> DuckDBStatement::GetSchema() const {
   return return_value;
 }
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_statement.h
+++ b/src/duckdb/duckdb_statement.h
@@ -25,22 +25,19 @@
 #include <arrow/flight/sql/column_metadata.h>
 #include <arrow/type_fwd.h>
 
-// clang-format off
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+#include "flight_sql_fwd.h"
 
-std::shared_ptr<DataType> GetDataTypeFromDuckDbType(
-        const duckdb::LogicalType duckdb_type
-);
+namespace sqlflite::ddb {
+
+std::shared_ptr<arrow::DataType> GetDataTypeFromDuckDbType(
+    const duckdb::LogicalType duckdb_type);
 
 /// \brief Create an object ColumnMetadata using the column type and
 ///        table name.
 /// \param column_type  The DuckDB type.
 /// \param table        The table name.
 /// \return             A Column Metadata object.
-ColumnMetadata GetColumnMetadata(int column_type, const char* table);
+flight::sql::ColumnMetadata GetColumnMetadata(int column_type, const char* table);
 
 class DuckDBStatement {
  public:
@@ -48,17 +45,17 @@ class DuckDBStatement {
   /// \param[in] db        duckdb database instance.
   /// \param[in] sql       SQL statement.
   /// \return              A DuckDBStatement object.
-  static arrow::Result<std::shared_ptr<DuckDBStatement>> Create(std::shared_ptr<duckdb::Connection> con,
-                                                                const std::string& sql);
+  static arrow::Result<std::shared_ptr<DuckDBStatement>> Create(
+      std::shared_ptr<duckdb::Connection> con, const std::string& sql);
 
   ~DuckDBStatement();
 
   /// \brief Creates an Arrow Schema based on the results of this statement.
   /// \return              The resulting Schema.
-  arrow::Result<std::shared_ptr<Schema>> GetSchema() const;
+  arrow::Result<std::shared_ptr<arrow::Schema>> GetSchema() const;
 
   arrow::Result<int> Execute();
-  arrow::Result<std::shared_ptr<RecordBatch>> FetchResult();
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> FetchResult();
   // arrow::Result<std::shared_ptr<Schema>> GetArrowSchema();
 
   std::shared_ptr<duckdb::PreparedStatement> GetDuckDBStmt() const;
@@ -69,20 +66,16 @@ class DuckDBStatement {
 
   duckdb::vector<duckdb::Value> bind_parameters;
 
-private:
+ private:
   std::shared_ptr<duckdb::Connection> con_;
   std::shared_ptr<duckdb::PreparedStatement> stmt_;
   duckdb::unique_ptr<duckdb::QueryResult> query_result_;
 
-  DuckDBStatement(
-    std::shared_ptr<duckdb::Connection> con, 
-    std::shared_ptr<duckdb::PreparedStatement> stmt) {
+  DuckDBStatement(std::shared_ptr<duckdb::Connection> con,
+                  std::shared_ptr<duckdb::PreparedStatement> stmt) {
     con_ = con;
     stmt_ = stmt;
   }
 };
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_statement_batch_reader.cpp
+++ b/src/duckdb/duckdb_statement_batch_reader.cpp
@@ -26,19 +26,17 @@
 
 #include "duckdb_statement.h"
 
-// clang-format off
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
 // Batch size for SQLite statement results
 static constexpr int kMaxBatchSize = 1024;
 
-std::shared_ptr<Schema> DuckDBStatementBatchReader::schema() const { return schema_; }
+std::shared_ptr<arrow::Schema> DuckDBStatementBatchReader::schema() const {
+  return schema_;
+}
 
 DuckDBStatementBatchReader::DuckDBStatementBatchReader(
-    std::shared_ptr<DuckDBStatement> statement, std::shared_ptr<Schema> schema)
+    std::shared_ptr<DuckDBStatement> statement, std::shared_ptr<arrow::Schema> schema)
     : statement_(std::move(statement)),
       schema_(std::move(schema)),
       rc_(DuckDBSuccess),
@@ -57,25 +55,22 @@ DuckDBStatementBatchReader::Create(const std::shared_ptr<DuckDBStatement>& state
 
 arrow::Result<std::shared_ptr<DuckDBStatementBatchReader>>
 DuckDBStatementBatchReader::Create(const std::shared_ptr<DuckDBStatement>& statement,
-                                   const std::shared_ptr<Schema>& schema) {
+                                   const std::shared_ptr<arrow::Schema>& schema) {
   std::shared_ptr<DuckDBStatementBatchReader> result(
       new DuckDBStatementBatchReader(statement, schema));
 
   return result;
 }
 
-Status DuckDBStatementBatchReader::ReadNext(std::shared_ptr<RecordBatch>* out) {
-
+arrow::Status DuckDBStatementBatchReader::ReadNext(
+    std::shared_ptr<arrow::RecordBatch>* out) {
   if (!already_executed_) {
     ARROW_ASSIGN_OR_RAISE(rc_, statement_->Execute());
     already_executed_ = true;
   }
   ARROW_ASSIGN_OR_RAISE(*out, statement_->FetchResult());
 
-  return Status::OK();
+  return arrow::Status::OK();
 }
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_statement_batch_reader.h
+++ b/src/duckdb/duckdb_statement_batch_reader.h
@@ -21,14 +21,11 @@
 #include <memory>
 #include <arrow/record_batch.h>
 #include "duckdb_statement.h"
+#include "flight_sql_fwd.h"
 
-// clang-format off
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
-class DuckDBStatementBatchReader : public RecordBatchReader {
+class DuckDBStatementBatchReader : public arrow::RecordBatchReader {
  public:
   /// \brief Creates a RecordBatchReader backed by a duckdb statement.
   /// \param[in] statement    duckdb statement to be read.
@@ -42,24 +39,21 @@ class DuckDBStatementBatchReader : public RecordBatchReader {
   /// \return                 A DuckDBStatementBatchReader..
   static arrow::Result<std::shared_ptr<DuckDBStatementBatchReader>> Create(
       const std::shared_ptr<DuckDBStatement>& statement,
-      const std::shared_ptr<Schema>& schema);
+      const std::shared_ptr<arrow::Schema>& schema);
 
-  std::shared_ptr<Schema> schema() const override;
+  std::shared_ptr<arrow::Schema> schema() const override;
 
-  Status ReadNext(std::shared_ptr<RecordBatch>* out) override;
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override;
 
  private:
   std::shared_ptr<DuckDBStatement> statement_;
-  std::shared_ptr<Schema> schema_;
+  std::shared_ptr<arrow::Schema> schema_;
   int rc_;
   bool already_executed_;
   bool results_read_;
 
   DuckDBStatementBatchReader(std::shared_ptr<DuckDBStatement> statement,
-                             std::shared_ptr<Schema> schema);
+                             std::shared_ptr<arrow::Schema> schema);
 };
 
-}  // namespace duckdbflight
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_tables_schema_batch_reader.cpp
+++ b/src/duckdb/duckdb_tables_schema_batch_reader.cpp
@@ -27,73 +27,73 @@
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
 
-// clang-format off
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+#include "flight_sql_fwd.h"
 
-std::shared_ptr<Schema> DuckDBTablesWithSchemaBatchReader::schema() const {
-  return SqlSchema::GetTablesSchemaWithIncludedSchema();
+using arrow::Status;
+
+namespace sqlflite::ddb {
+
+std::shared_ptr<arrow::Schema> DuckDBTablesWithSchemaBatchReader::schema() const {
+  return flight::sql::SqlSchema::GetTablesSchemaWithIncludedSchema();
 }
 
-Status DuckDBTablesWithSchemaBatchReader::ReadNext(std::shared_ptr<RecordBatch>* batch) {
+Status DuckDBTablesWithSchemaBatchReader::ReadNext(
+    std::shared_ptr<arrow::RecordBatch> *batch) {
   if (already_executed_) {
+    *batch = NULLPTR;
+    return Status::OK();
+  } else {
+    std::shared_ptr<DuckDBStatement> schema_statement;
+    ARROW_ASSIGN_OR_RAISE(schema_statement,
+                          DuckDBStatement::Create(db_conn_, main_query_));
+
+    std::shared_ptr<arrow::RecordBatch> first_batch;
+
+    ARROW_RETURN_NOT_OK(reader_->ReadNext(&first_batch));
+
+    if (!first_batch) {
       *batch = NULLPTR;
       return Status::OK();
+    }
+
+    const std::shared_ptr<arrow::Array> table_name_array =
+        first_batch->GetColumnByName("table_name");
+
+    arrow::BinaryBuilder schema_builder;
+
+    auto *string_array = reinterpret_cast<arrow::StringArray *>(table_name_array.get());
+
+    for (int table_name_index = 0; table_name_index < table_name_array->length();
+         table_name_index++) {
+      const std::string &table_name = string_array->GetString(table_name_index);
+
+      // Just get the schema from a prepared statement
+      std::shared_ptr<DuckDBStatement> table_schema_statement;
+      ARROW_ASSIGN_OR_RAISE(
+          table_schema_statement,
+          DuckDBStatement::Create(db_conn_,
+                                  "SELECT * FROM " + table_name + " WHERE 1 = 0"));
+
+      ARROW_ASSIGN_OR_RAISE(auto table_schema, table_schema_statement->GetSchema());
+
+      const arrow::Result<std::shared_ptr<arrow::Buffer>> &value =
+          arrow::ipc::SerializeSchema(*table_schema);
+
+      std::shared_ptr<arrow::Buffer> schema_buffer;
+      ARROW_ASSIGN_OR_RAISE(schema_buffer, value);
+
+      ARROW_RETURN_NOT_OK(schema_builder.Append(::std::string_view(*schema_buffer)));
+    }
+
+    std::shared_ptr<arrow::Array> schema_array;
+    ARROW_RETURN_NOT_OK(schema_builder.Finish(&schema_array));
+
+    ARROW_ASSIGN_OR_RAISE(*batch,
+                          first_batch->AddColumn(4, "table_schema", schema_array));
+    already_executed_ = true;
+
+    return Status::OK();
   }
-  else {
-      std::shared_ptr<DuckDBStatement> schema_statement;
-      ARROW_ASSIGN_OR_RAISE(schema_statement,
-                            DuckDBStatement::Create(db_conn_, main_query_));
-
-      std::shared_ptr<RecordBatch> first_batch;
-
-      ARROW_RETURN_NOT_OK(reader_->ReadNext(&first_batch));
-
-      if (!first_batch) {
-          *batch = NULLPTR;
-          return Status::OK();
-      }
-
-      const std::shared_ptr<Array> table_name_array =
-              first_batch->GetColumnByName("table_name");
-
-      BinaryBuilder schema_builder;
-
-      auto *string_array = reinterpret_cast<StringArray *>(table_name_array.get());
-
-      for (int table_name_index = 0; table_name_index < table_name_array->length(); table_name_index++) {
-          const std::string &table_name = string_array->GetString(table_name_index);
-
-          // Just get the schema from a prepared statement
-          std::shared_ptr<DuckDBStatement> table_schema_statement;
-          ARROW_ASSIGN_OR_RAISE(table_schema_statement,
-                                DuckDBStatement::Create(db_conn_, "SELECT * FROM " + table_name + " WHERE 1 = 0"));
-
-          ARROW_ASSIGN_OR_RAISE(auto table_schema, table_schema_statement->GetSchema());
-
-          const arrow::Result<std::shared_ptr<Buffer>> &value =
-                  ipc::SerializeSchema(*table_schema);
-
-          std::shared_ptr<Buffer> schema_buffer;
-          ARROW_ASSIGN_OR_RAISE(schema_buffer, value);
-
-          ARROW_RETURN_NOT_OK(schema_builder.Append(::std::string_view(*schema_buffer)));
-      }
-
-      std::shared_ptr<Array> schema_array;
-      ARROW_RETURN_NOT_OK(schema_builder.Finish(&schema_array));
-
-      ARROW_ASSIGN_OR_RAISE(*batch, first_batch->AddColumn(4, "table_schema", schema_array));
-      already_executed_ = true;
-
-      return Status::OK();
-  }
-
 }
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/duckdb/duckdb_tables_schema_batch_reader.h
+++ b/src/duckdb/duckdb_tables_schema_batch_reader.h
@@ -26,13 +26,9 @@
 #include "duckdb_statement_batch_reader.h"
 #include "arrow/record_batch.h"
 
-// clang-format off
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace duckdbflight {
+namespace sqlflite::ddb {
 
-class DuckDBTablesWithSchemaBatchReader : public RecordBatchReader {
+class DuckDBTablesWithSchemaBatchReader : public arrow::RecordBatchReader {
  private:
   std::shared_ptr<DuckDBStatementBatchReader> reader_;
   std::string main_query_;
@@ -44,17 +40,17 @@ class DuckDBTablesWithSchemaBatchReader : public RecordBatchReader {
   /// \param reader an shared_ptr from a DuckDBStatementBatchReader.
   /// \param main_query  SQL query that originated reader's data.
   /// \param db     a pointer to the sqlite3 db.
-  DuckDBTablesWithSchemaBatchReader(
-          std::shared_ptr<DuckDBStatementBatchReader> reader, std::string main_query,
-          std::shared_ptr<duckdb::Connection> db_conn)
-      : reader_(std::move(reader)), main_query_(std::move(main_query)), db_conn_(db_conn), already_executed_(false) {}
+  DuckDBTablesWithSchemaBatchReader(std::shared_ptr<DuckDBStatementBatchReader> reader,
+                                    std::string main_query,
+                                    std::shared_ptr<duckdb::Connection> db_conn)
+      : reader_(std::move(reader)),
+        main_query_(std::move(main_query)),
+        db_conn_(db_conn),
+        already_executed_(false) {}
 
-  std::shared_ptr<Schema> schema() const override;
+  std::shared_ptr<arrow::Schema> schema() const override;
 
-  Status ReadNext(std::shared_ptr<RecordBatch>* batch) override;
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override;
 };
 
-}  // namespace duckdb
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::ddb

--- a/src/library/include/flight_sql_fwd.h
+++ b/src/library/include/flight_sql_fwd.h
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace arrow::flight {}
+
+namespace flight = arrow::flight;

--- a/src/library/include/sqlflite_library.h
+++ b/src/library/include/sqlflite_library.h
@@ -28,8 +28,6 @@ const int DEFAULT_FLIGHT_PORT = 31337;
 
 enum class BackendType { duckdb, sqlite };
 
-namespace fs = std::filesystem;
-
 /**
  * @brief Run a SQLFlite Server with the specified configuration.
  *
@@ -57,13 +55,14 @@ namespace fs = std::filesystem;
  */
 
 extern "C" {
-int RunFlightSQLServer(const BackendType backend, fs::path &database_filename,
-                       std::string hostname = "", const int &port = DEFAULT_FLIGHT_PORT,
-                       std::string username = "", std::string password = "",
-                       std::string secret_key = "", fs::path tls_cert_path = fs::path(),
-                       fs::path tls_key_path = fs::path(),
-                       fs::path mtls_ca_cert_path = fs::path(),
-                       std::string init_sql_commands = "",
-                       fs::path init_sql_commands_file = fs::path(),
-                       const bool &print_queries = false);
+int RunFlightSQLServer(
+    const BackendType backend, std::filesystem::path &database_filename,
+    std::string hostname = "", const int &port = DEFAULT_FLIGHT_PORT,
+    std::string username = "", std::string password = "", std::string secret_key = "",
+    std::filesystem::path tls_cert_path = std::filesystem::path(),
+    std::filesystem::path tls_key_path = std::filesystem::path(),
+    std::filesystem::path mtls_ca_cert_path = std::filesystem::path(),
+    std::string init_sql_commands = "",
+    std::filesystem::path init_sql_commands_file = std::filesystem::path(),
+    const bool &print_queries = false);
 }

--- a/src/library/include/sqlflite_library.h
+++ b/src/library/include/sqlflite_library.h
@@ -1,4 +1,20 @@
-// sqlflite_library.h
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #pragma once
 
 #include <filesystem>

--- a/src/library/include/sqlflite_security.h
+++ b/src/library/include/sqlflite_security.h
@@ -1,6 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Created by Philip Moore on 11/14/22.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include <filesystem>
 #include <arrow/flight/sql/server.h>
 #include <arrow/flight/server_auth.h>

--- a/src/library/sqlflite_library.cpp
+++ b/src/library/sqlflite_library.cpp
@@ -114,12 +114,10 @@ FlightSQLServerBuilder(const BackendType backend, const fs::path &database_filen
     server = sqlite_server;
   } else if (backend == BackendType::duckdb) {
     db_type = "DuckDB";
-    std::shared_ptr<arrow::flight::sql::duckdbflight::DuckDBFlightSqlServer>
-        duckdb_server = nullptr;
+    std::shared_ptr<sqlflite::ddb::DuckDBFlightSqlServer> duckdb_server = nullptr;
     duckdb::DBConfig config;
-    ARROW_ASSIGN_OR_RAISE(duckdb_server,
-                          arrow::flight::sql::duckdbflight::DuckDBFlightSqlServer::Create(
-                              database_filename, config, print_queries))
+    ARROW_ASSIGN_OR_RAISE(duckdb_server, sqlflite::ddb::DuckDBFlightSqlServer::Create(
+                                             database_filename, config, print_queries))
     // Run additional commands (first) for the DuckDB back-end...
     auto duckdb_init_sql_commands =
         "SET autoinstall_known_extensions = true; SET autoload_known_extensions = true;" +

--- a/src/library/sqlflite_library.cpp
+++ b/src/library/sqlflite_library.cpp
@@ -33,10 +33,12 @@
 
 #include "sqlite_server.h"
 #include "duckdb_server.h"
+#include "include/flight_sql_fwd.h"
 #include "include/sqlflite_security.h"
 
-namespace flight = arrow::flight;
-namespace flightsql = arrow::flight::sql;
+namespace fs = std::filesystem;
+
+namespace sqlflite {
 
 const int port = 31337;
 
@@ -58,24 +60,24 @@ const int port = 31337;
     }                                                                              \
   } while (false)
 
-arrow::Result<std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>>
-FlightSQLServerBuilder(const BackendType backend, const fs::path &database_filename,
-                       const std::string &hostname, const int &port,
-                       const std::string &username, const std::string &password,
-                       const std::string &secret_key, const fs::path &tls_cert_path,
-                       const fs::path &tls_key_path, const fs::path &mtls_ca_cert_path,
-                       const std::string &init_sql_commands, const bool &print_queries) {
+arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServerBuilder(
+    const BackendType backend, const fs::path &database_filename,
+    const std::string &hostname, const int &port, const std::string &username,
+    const std::string &password, const std::string &secret_key,
+    const fs::path &tls_cert_path, const fs::path &tls_key_path,
+    const fs::path &mtls_ca_cert_path, const std::string &init_sql_commands,
+    const bool &print_queries) {
   ARROW_ASSIGN_OR_RAISE(auto location,
                         (!tls_cert_path.empty())
-                            ? arrow::flight::Location::ForGrpcTls(hostname, port)
-                            : arrow::flight::Location::ForGrpcTcp(hostname, port));
+                            ? flight::Location::ForGrpcTls(hostname, port)
+                            : flight::Location::ForGrpcTcp(hostname, port));
 
   std::cout << "Apache Arrow version: " << ARROW_VERSION_STRING << std::endl;
 
-  arrow::flight::FlightServerOptions options(location);
+  flight::FlightServerOptions options(location);
 
   if (!tls_cert_path.empty() && !tls_key_path.empty()) {
-    ARROW_CHECK_OK(arrow::flight::SecurityUtilities::FlightServerTlsCertificates(
+    ARROW_CHECK_OK(sqlflite::SecurityUtilities::FlightServerTlsCertificates(
         tls_cert_path, tls_key_path, &options.tls_certificates));
   } else {
     std::cout << "WARNING - TLS is disabled for the SQLFlite server - this is insecure."
@@ -83,24 +85,23 @@ FlightSQLServerBuilder(const BackendType backend, const fs::path &database_filen
   }
 
   // Setup authentication middleware (using the same TLS certificate keypair)
-  auto header_middleware =
-      std::make_shared<arrow::flight::HeaderAuthServerMiddlewareFactory>(
-          username, password, secret_key);
+  auto header_middleware = std::make_shared<sqlflite::HeaderAuthServerMiddlewareFactory>(
+      username, password, secret_key);
   auto bearer_middleware =
-      std::make_shared<arrow::flight::BearerAuthServerMiddlewareFactory>(secret_key);
+      std::make_shared<sqlflite::BearerAuthServerMiddlewareFactory>(secret_key);
 
-  options.auth_handler = std::make_unique<arrow::flight::NoOpAuthHandler>();
+  options.auth_handler = std::make_unique<flight::NoOpAuthHandler>();
   options.middleware.push_back({"header-auth-server", header_middleware});
   options.middleware.push_back({"bearer-auth-server", bearer_middleware});
 
   if (!mtls_ca_cert_path.empty()) {
     std::cout << "Using mTLS CA certificate: " << mtls_ca_cert_path << std::endl;
-    ARROW_CHECK_OK(arrow::flight::SecurityUtilities::FlightServerMtlsCACertificate(
+    ARROW_CHECK_OK(sqlflite::SecurityUtilities::FlightServerMtlsCACertificate(
         mtls_ca_cert_path, &options.root_certificates));
     options.verify_client = true;
   }
 
-  std::shared_ptr<arrow::flight::sql::FlightSqlServerBase> server = nullptr;
+  std::shared_ptr<flight::sql::FlightSqlServerBase> server = nullptr;
 
   std::string db_type = "";
   if (backend == BackendType::sqlite) {
@@ -155,13 +156,12 @@ std::string SafeGetEnvVarValue(const std::string &env_var_name) {
   }
 }
 
-arrow::Result<std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>>
-CreateFlightSQLServer(const BackendType backend, fs::path &database_filename,
-                      std::string hostname, const int &port, std::string username,
-                      std::string password, std::string secret_key,
-                      fs::path tls_cert_path, fs::path tls_key_path,
-                      fs::path mtls_ca_cert_path, std::string init_sql_commands,
-                      fs::path init_sql_commands_file, const bool &print_queries) {
+arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQLServer(
+    const BackendType backend, fs::path &database_filename, std::string hostname,
+    const int &port, std::string username, std::string password, std::string secret_key,
+    fs::path tls_cert_path, fs::path tls_key_path, fs::path mtls_ca_cert_path,
+    std::string init_sql_commands, fs::path init_sql_commands_file,
+    const bool &print_queries) {
   // Validate and default the arguments to env var values where applicable
   if (database_filename.empty()) {
     return arrow::Status::Invalid("The database filename was not provided!");
@@ -255,9 +255,13 @@ CreateFlightSQLServer(const BackendType backend, fs::path &database_filename,
 }
 
 arrow::Status StartFlightSQLServer(
-    std::shared_ptr<arrow::flight::sql::FlightSqlServerBase> server) {
+    std::shared_ptr<flight::sql::FlightSqlServerBase> server) {
   return arrow::Status::OK();
 }
+
+}  // namespace sqlflite
+
+extern "C" {
 
 int RunFlightSQLServer(const BackendType backend, fs::path &database_filename,
                        std::string hostname, const int &port, std::string username,
@@ -265,7 +269,7 @@ int RunFlightSQLServer(const BackendType backend, fs::path &database_filename,
                        fs::path tls_cert_path, fs::path tls_key_path,
                        fs::path mtls_ca_cert_path, std::string init_sql_commands,
                        fs::path init_sql_commands_file, const bool &print_queries) {
-  auto create_server_result = CreateFlightSQLServer(
+  auto create_server_result = sqlflite::CreateFlightSQLServer(
       backend, database_filename, hostname, port, username, password, secret_key,
       tls_cert_path, tls_key_path, mtls_ca_cert_path, init_sql_commands,
       init_sql_commands_file, print_queries);
@@ -280,4 +284,5 @@ int RunFlightSQLServer(const BackendType backend, fs::path &database_filename,
     std::cerr << "Error: " << create_server_result.status().ToString() << std::endl;
     return EXIT_FAILURE;
   }
+}
 }

--- a/src/library/sqlflite_library.cpp
+++ b/src/library/sqlflite_library.cpp
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "include/sqlflite_library.h"
 
 #include <cstdlib>

--- a/src/library/sqlflite_library.cpp
+++ b/src/library/sqlflite_library.cpp
@@ -105,11 +105,9 @@ FlightSQLServerBuilder(const BackendType backend, const fs::path &database_filen
   std::string db_type = "";
   if (backend == BackendType::sqlite) {
     db_type = "SQLite";
-    std::shared_ptr<arrow::flight::sql::sqlite::SQLiteFlightSqlServer> sqlite_server =
-        nullptr;
-    ARROW_ASSIGN_OR_RAISE(
-        sqlite_server,
-        arrow::flight::sql::sqlite::SQLiteFlightSqlServer::Create(database_filename))
+    std::shared_ptr<sqlflite::sqlite::SQLiteFlightSqlServer> sqlite_server = nullptr;
+    ARROW_ASSIGN_OR_RAISE(sqlite_server, sqlflite::sqlite::SQLiteFlightSqlServer::Create(
+                                             database_filename));
     RUN_INIT_COMMANDS(sqlite_server, init_sql_commands);
     server = sqlite_server;
   } else if (backend == BackendType::duckdb) {

--- a/src/library/sqlflite_security.cpp
+++ b/src/library/sqlflite_security.cpp
@@ -1,6 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
 //
-// Created by Philip Moore on 11/14/22.
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "include/sqlflite_security.h"
 
 namespace fs = std::filesystem;

--- a/src/library/sqlflite_security.cpp
+++ b/src/library/sqlflite_security.cpp
@@ -19,8 +19,9 @@
 
 namespace fs = std::filesystem;
 
-namespace arrow {
-namespace flight {
+using arrow::Status;
+
+namespace sqlflite {
 
 const std::string kJWTIssuer = "sqlflite";
 const int kJWTExpiration = 24 * 3600;
@@ -30,13 +31,13 @@ const std::string kBearerPrefix = "Bearer ";
 const std::string kAuthHeader = "authorization";
 
 // ----------------------------------------
-Status SecurityUtilities::FlightServerTlsCertificates(const fs::path &cert_path,
-                                                      const fs::path &key_path,
-                                                      std::vector<CertKeyPair> *out) {
+Status SecurityUtilities::FlightServerTlsCertificates(
+    const fs::path &cert_path, const fs::path &key_path,
+    std::vector<flight::CertKeyPair> *out) {
   std::cout << "Using TLS Cert file: " << cert_path << std::endl;
   std::cout << "Using TLS Key file: " << key_path << std::endl;
 
-  *out = std::vector<CertKeyPair>();
+  *out = std::vector<flight::CertKeyPair>();
   try {
     std::ifstream cert_file(cert_path);
     if (!cert_file) {
@@ -52,7 +53,7 @@ Status SecurityUtilities::FlightServerTlsCertificates(const fs::path &cert_path,
     std::stringstream key;
     key << key_file.rdbuf();
 
-    out->push_back(CertKeyPair{cert.str(), key.str()});
+    out->push_back(flight::CertKeyPair{cert.str(), key.str()});
   } catch (const std::ifstream::failure &e) {
     return Status::IOError(e.what());
   }
@@ -79,7 +80,7 @@ Status SecurityUtilities::FlightServerMtlsCACertificate(const std::string &cert_
 // Function to look in CallHeaders for a key that has a value starting with prefix and
 // return the rest of the value after the prefix.
 std::string SecurityUtilities::FindKeyValPrefixInCallHeaders(
-    const CallHeaders &incoming_headers, const std::string &key,
+    const flight::CallHeaders &incoming_headers, const std::string &key,
     const std::string &prefix) {
   // Lambda function to compare characters without case sensitivity.
   auto char_compare = [](const char &char1, const char &char2) {
@@ -100,7 +101,7 @@ std::string SecurityUtilities::FindKeyValPrefixInCallHeaders(
   return "";
 }
 
-Status SecurityUtilities::GetAuthHeaderType(const CallHeaders &incoming_headers,
+Status SecurityUtilities::GetAuthHeaderType(const flight::CallHeaders &incoming_headers,
                                             std::string *out) {
   if (!FindKeyValPrefixInCallHeaders(incoming_headers, kAuthHeader, kBasicPrefix)
            .empty()) {
@@ -114,7 +115,7 @@ Status SecurityUtilities::GetAuthHeaderType(const CallHeaders &incoming_headers,
   return Status::OK();
 }
 
-void SecurityUtilities::ParseBasicHeader(const CallHeaders &incoming_headers,
+void SecurityUtilities::ParseBasicHeader(const flight::CallHeaders &incoming_headers,
                                          std::string &username, std::string &password) {
   std::string encoded_credentials =
       FindKeyValPrefixInCallHeaders(incoming_headers, kAuthHeader, kBasicPrefix);
@@ -128,7 +129,8 @@ HeaderAuthServerMiddleware::HeaderAuthServerMiddleware(const std::string &userna
                                                        const std::string &secret_key)
     : username_(username), secret_key_(secret_key) {}
 
-void HeaderAuthServerMiddleware::SendingHeaders(AddCallHeaders *outgoing_headers) {
+void HeaderAuthServerMiddleware::SendingHeaders(
+    flight::AddCallHeaders *outgoing_headers) {
   auto token = CreateJWTToken();
   outgoing_headers->AddHeader(kAuthHeader, std::string(kBearerPrefix) + token);
 }
@@ -161,8 +163,8 @@ HeaderAuthServerMiddlewareFactory::HeaderAuthServerMiddlewareFactory(
     : username_(username), password_(password), secret_key_(secret_key) {}
 
 Status HeaderAuthServerMiddlewareFactory::StartCall(
-    const CallInfo &info, const CallHeaders &incoming_headers,
-    std::shared_ptr<ServerMiddleware> *middleware) {
+    const flight::CallInfo &info, const flight::CallHeaders &incoming_headers,
+    std::shared_ptr<flight::ServerMiddleware> *middleware) {
   std::string auth_header_type;
   ARROW_RETURN_NOT_OK(
       SecurityUtilities::GetAuthHeaderType(incoming_headers, &auth_header_type));
@@ -175,7 +177,8 @@ Status HeaderAuthServerMiddlewareFactory::StartCall(
     if ((username == username_) && (password == password_)) {
       *middleware = std::make_shared<HeaderAuthServerMiddleware>(username, secret_key_);
     } else {
-      return MakeFlightError(FlightStatusCode::Unauthenticated, "Invalid credentials");
+      return MakeFlightError(flight::FlightStatusCode::Unauthenticated,
+                             "Invalid credentials");
     }
   }
   return Status::OK();
@@ -183,11 +186,12 @@ Status HeaderAuthServerMiddlewareFactory::StartCall(
 
 // ----------------------------------------
 BearerAuthServerMiddleware::BearerAuthServerMiddleware(
-    const std::string &secret_key, const CallHeaders &incoming_headers,
+    const std::string &secret_key, const flight::CallHeaders &incoming_headers,
     std::optional<bool> *isValid)
     : secret_key_(secret_key), incoming_headers_(incoming_headers), isValid_(isValid) {}
 
-void BearerAuthServerMiddleware::SendingHeaders(AddCallHeaders *outgoing_headers) {
+void BearerAuthServerMiddleware::SendingHeaders(
+    flight::AddCallHeaders *outgoing_headers) {
   std::string bearer_token = SecurityUtilities::FindKeyValPrefixInCallHeaders(
       incoming_headers_, kAuthHeader, kBearerPrefix);
   *isValid_ = (VerifyToken(bearer_token));
@@ -225,10 +229,11 @@ BearerAuthServerMiddlewareFactory::BearerAuthServerMiddlewareFactory(
     : secret_key_(secret_key) {}
 
 Status BearerAuthServerMiddlewareFactory::StartCall(
-    const CallInfo &info, const CallHeaders &incoming_headers,
-    std::shared_ptr<ServerMiddleware> *middleware) {
-  if (const std::pair<CallHeaders::const_iterator, CallHeaders::const_iterator>
-          &iter_pair = incoming_headers.equal_range(kAuthHeader);
+    const flight::CallInfo &info, const flight::CallHeaders &incoming_headers,
+    std::shared_ptr<flight::ServerMiddleware> *middleware) {
+  if (const std::pair<flight::CallHeaders::const_iterator,
+                      flight::CallHeaders::const_iterator> &iter_pair =
+          incoming_headers.equal_range(kAuthHeader);
       iter_pair.first != iter_pair.second) {
     std::string auth_header_type;
     ARROW_RETURN_NOT_OK(
@@ -241,7 +246,7 @@ Status BearerAuthServerMiddlewareFactory::StartCall(
   if (isValid_.has_value() && !*isValid_) {
     isValid_.reset();
 
-    return MakeFlightError(FlightStatusCode::Unauthenticated,
+    return MakeFlightError(flight::FlightStatusCode::Unauthenticated,
                            "Invalid bearer token provided");
   }
 
@@ -250,5 +255,4 @@ Status BearerAuthServerMiddlewareFactory::StartCall(
 
 std::optional<bool> BearerAuthServerMiddlewareFactory::GetIsValid() { return isValid_; }
 
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite

--- a/src/sqlflite_server.cpp
+++ b/src/sqlflite_server.cpp
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "library/include/sqlflite_library.h"
 #include <iostream>
 #include <boost/program_options.hpp>

--- a/src/sqlflite_server.cpp
+++ b/src/sqlflite_server.cpp
@@ -20,6 +20,7 @@
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
+namespace fs = std::filesystem;
 
 int main(int argc, char **argv) {
   std::vector<std::string> tls_token_values;

--- a/src/sqlite/sqlite_sql_info.cc
+++ b/src/sqlite/sqlite_sql_info.cc
@@ -19,15 +19,15 @@
 
 #include "arrow/flight/sql/types.h"
 #include "arrow/util/config.h"
+#include "flight_sql_fwd.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
 /// \brief Gets the mapping from SQL info ids to SqlInfoResult instances.
 /// \return the cache.
-SqlInfoResultMap GetSqlInfoResultMap() {
+flight::sql::SqlInfoResultMap GetSqlInfoResultMap() {
+  using SqlInfoOptions = flight::sql::SqlInfoOptions;
+  using SqlInfoResult = flight::sql::SqlInfoResult;
   return {
       {SqlInfoOptions::SqlInfo::FLIGHT_SQL_SERVER_NAME,
        SqlInfoResult(std::string("db_name"))},
@@ -48,17 +48,17 @@ SqlInfoResultMap GetSqlInfoResultMap() {
        SqlInfoResult(false /* SQLite 3 does not support schemas */)},
       {SqlInfoOptions::SqlInfo::SQL_DDL_TABLE, SqlInfoResult(true)},
       {SqlInfoOptions::SqlInfo::SQL_IDENTIFIER_CASE,
-       SqlInfoResult(int64_t(SqlInfoOptions::SqlSupportedCaseSensitivity::
-                                 SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
+       SqlInfoResult(static_cast<int64_t>(SqlInfoOptions::SqlSupportedCaseSensitivity::
+                                              SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
       {SqlInfoOptions::SqlInfo::SQL_IDENTIFIER_QUOTE_CHAR,
        SqlInfoResult(std::string("\""))},
       {SqlInfoOptions::SqlInfo::SQL_QUOTED_IDENTIFIER_CASE,
-       SqlInfoResult(int64_t(SqlInfoOptions::SqlSupportedCaseSensitivity::
-                                 SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
+       SqlInfoResult(static_cast<int64_t>(SqlInfoOptions::SqlSupportedCaseSensitivity::
+                                              SQL_CASE_SENSITIVITY_CASE_INSENSITIVE))},
       {SqlInfoOptions::SqlInfo::SQL_ALL_TABLES_ARE_SELECTABLE, SqlInfoResult(true)},
       {SqlInfoOptions::SqlInfo::SQL_NULL_ORDERING,
-       SqlInfoResult(
-           int64_t(SqlInfoOptions::SqlNullOrdering::SQL_NULLS_SORTED_AT_START))},
+       SqlInfoResult(static_cast<int64_t>(
+           SqlInfoOptions::SqlNullOrdering::SQL_NULLS_SORTED_AT_START))},
       {SqlInfoOptions::SqlInfo::SQL_KEYWORDS,
        SqlInfoResult(std::vector<std::string>({"ABORT",
                                                "ACTION",
@@ -224,7 +224,4 @@ SqlInfoResultMap GetSqlInfoResultMap() {
                  {SqlInfoOptions::SqlSupportsConvert::SQL_CONVERT_INTEGER})}}))}};
 }
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::sqlite

--- a/src/sqlite/sqlite_sql_info.h
+++ b/src/sqlite/sqlite_sql_info.h
@@ -19,16 +19,10 @@
 
 #include "arrow/flight/sql/types.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
 /// \brief Gets the mapping from SQL info ids to SqlInfoResult instances.
 /// \return the cache.
-SqlInfoResultMap GetSqlInfoResultMap();
+arrow::flight::sql::SqlInfoResultMap GetSqlInfoResultMap();
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::sqlite

--- a/src/sqlite/sqlite_statement.h
+++ b/src/sqlite/sqlite_statement.h
@@ -25,17 +25,14 @@
 #include "arrow/flight/sql/column_metadata.h"
 #include "arrow/type_fwd.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
 /// \brief Create an object ColumnMetadata using the column type and
 ///        table name.
 /// \param column_type  The SQLite type.
 /// \param table        The table name.
 /// \return             A Column Metadata object.
-ColumnMetadata GetColumnMetadata(int column_type, const char* table);
+arrow::flight::sql::ColumnMetadata GetColumnMetadata(int column_type, const char* table);
 
 class SqliteStatement {
  public:
@@ -50,7 +47,7 @@ class SqliteStatement {
 
   /// \brief Creates an Arrow Schema based on the results of this statement.
   /// \return              The resulting Schema.
-  arrow::Result<std::shared_ptr<Schema>> GetSchema() const;
+  arrow::Result<std::shared_ptr<arrow::Schema>> GetSchema() const;
 
   /// \brief Steps on underlying sqlite3_stmt.
   /// \return          The resulting return code from SQLite.
@@ -73,8 +70,9 @@ class SqliteStatement {
   const std::vector<std::shared_ptr<arrow::RecordBatch>>& parameters() const {
     return parameters_;
   }
-  Status SetParameters(std::vector<std::shared_ptr<arrow::RecordBatch>> parameters);
-  Status Bind(size_t batch_index, int64_t row_index);
+  arrow::Status SetParameters(
+      std::vector<std::shared_ptr<arrow::RecordBatch>> parameters);
+  arrow::Status Bind(size_t batch_index, int64_t row_index);
 
  private:
   sqlite3* db_;
@@ -84,7 +82,4 @@ class SqliteStatement {
   SqliteStatement(sqlite3* db, sqlite3_stmt* stmt) : db_(db), stmt_(stmt) {}
 };
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::sqlite

--- a/src/sqlite/sqlite_statement_batch_reader.h
+++ b/src/sqlite/sqlite_statement_batch_reader.h
@@ -24,12 +24,9 @@
 #include "sqlite_statement.h"
 #include "arrow/record_batch.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
-class SqliteStatementBatchReader : public RecordBatchReader {
+class SqliteStatementBatchReader : public arrow::RecordBatchReader {
  public:
   /// \brief Creates a RecordBatchReader backed by a SQLite statement.
   /// \param[in] statement    SQLite statement to be read.
@@ -43,15 +40,15 @@ class SqliteStatementBatchReader : public RecordBatchReader {
   /// \return                 A SqliteStatementBatchReader..
   static arrow::Result<std::shared_ptr<SqliteStatementBatchReader>> Create(
       const std::shared_ptr<SqliteStatement>& statement,
-      const std::shared_ptr<Schema>& schema);
+      const std::shared_ptr<arrow::Schema>& schema);
 
-  std::shared_ptr<Schema> schema() const override;
+  std::shared_ptr<arrow::Schema> schema() const override;
 
-  Status ReadNext(std::shared_ptr<RecordBatch>* out) override;
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override;
 
  private:
   std::shared_ptr<SqliteStatement> statement_;
-  std::shared_ptr<Schema> schema_;
+  std::shared_ptr<arrow::Schema> schema_;
   int rc_;
   bool already_executed_;
 
@@ -60,10 +57,7 @@ class SqliteStatementBatchReader : public RecordBatchReader {
   int64_t row_index_{0};
 
   SqliteStatementBatchReader(std::shared_ptr<SqliteStatement> statement,
-                             std::shared_ptr<Schema> schema);
+                             std::shared_ptr<arrow::Schema> schema);
 };
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::sqlite

--- a/src/sqlite/sqlite_tables_schema_batch_reader.h
+++ b/src/sqlite/sqlite_tables_schema_batch_reader.h
@@ -26,12 +26,9 @@
 #include "sqlite_statement_batch_reader.h"
 #include "arrow/record_batch.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
-class SqliteTablesWithSchemaBatchReader : public RecordBatchReader {
+class SqliteTablesWithSchemaBatchReader : public arrow::RecordBatchReader {
  private:
   std::shared_ptr<sqlite::SqliteStatementBatchReader> reader_;
   std::string main_query_;
@@ -47,12 +44,9 @@ class SqliteTablesWithSchemaBatchReader : public RecordBatchReader {
       sqlite3* db)
       : reader_(std::move(reader)), main_query_(std::move(main_query)), db_(db) {}
 
-  std::shared_ptr<Schema> schema() const override;
+  std::shared_ptr<arrow::Schema> schema() const override;
 
-  Status ReadNext(std::shared_ptr<RecordBatch>* batch) override;
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override;
 };
 
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+}  // namespace sqlflite::sqlite

--- a/src/sqlite/sqlite_type_info.h
+++ b/src/sqlite/sqlite_type_info.h
@@ -19,20 +19,16 @@
 
 #include "arrow/record_batch.h"
 
-namespace arrow {
-namespace flight {
-namespace sql {
-namespace sqlite {
+namespace sqlflite::sqlite {
 
 /// \brief Gets the hard-coded type info from Sqlite for all data types.
 /// \return A record batch.
-arrow::Result<std::shared_ptr<RecordBatch>> DoGetTypeInfoResult();
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> DoGetTypeInfoResult();
 
 /// \brief Gets the hard-coded type info from Sqlite filtering
 ///        for a specific data type.
 /// \return A record batch.
-arrow::Result<std::shared_ptr<RecordBatch>> DoGetTypeInfoResult(int data_type_filter);
-}  // namespace sqlite
-}  // namespace sql
-}  // namespace flight
-}  // namespace arrow
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> DoGetTypeInfoResult(
+    int data_type_filter);
+
+}  // namespace sqlflite::sqlite


### PR DESCRIPTION
Instead of defining symbols inside of the namespace of the projects we use (e.g. arrow). There are two problems with this: risk of nasty linker errors if symbols collide and difficulties in understanding from which project a symbol comes from (is it a class defined in this project or a class from Arrow).

Defining template aliases in headers is not recommended, but for convenience one alias is defined: `flight = arrow::flight` since we reference this namespace **a lot** from the code. Many aliases that were defined in .h files are now removed.